### PR TITLE
chat_script に説明コメントを追加

### DIFF
--- a/chat_script.ipynb
+++ b/chat_script.ipynb
@@ -1,4 +1,4 @@
-from pyspark.sql import SparkSession
+from pyspark.sql import SparkSession, DataFrame
 from pyspark.sql.functions import *
 from pyspark.sql.window import Window
 from pyspark.sql.types import *
@@ -17,6 +17,29 @@ def complement_with_local_insertion(
     SUPPORT_DEFAULT: str = "S006",
     HEAD_INSERT_FOR_MISSING_PROPOSAL: bool = True
 ) -> DataFrame:
+    """
+    routing_select に不足している提案やサポートを補完する。
+
+    各 selection の直前に proposal と support が存在することを保証するため、
+    不足している要素を先頭またはローカル位置に挿入して配列を再構築する。
+
+    Parameters
+    ----------
+    chat_df : DataFrame
+        発話情報と routing_select を持つデータセット
+    scenario_master_df : DataFrame
+        シナリオIDと route 種別の対応表
+    SUPPORT_DEFAULT : str, optional
+        サポートが見つからない場合に使用するデフォルトID（既定値: "S006"）
+    HEAD_INSERT_FOR_MISSING_PROPOSAL : bool, optional
+        True の場合、提案が無い selection への挿入を先頭に集約する
+
+    Returns
+    -------
+    DataFrame
+        補完後の routing_select と挿入数などの付加情報を含むデータセット
+    """
+
     spark = chat_df.sql_ctx.sparkSession
 
     # ---------- 基本の展開 ----------
@@ -25,7 +48,7 @@ def complement_with_local_insertion(
         posexplode("routing_select").alias("position", "scenario_id")
     ).join(broadcast(scenario_master_df), "scenario_id", "left")
 
-    # 各種フィルタビュー
+    # 各 route ごとの行に分割し、後続処理用に位置情報を保持
     sel = expl.filter(col("route") == "選択") \
               .select("utterance_id","user_id","utterance_start_time","position") \
               .withColumnRenamed("position","sel_pos")
@@ -118,7 +141,7 @@ def complement_with_local_insertion(
     )
 
     per_selection = per_selection.join(
-        last_supp_before_refprop,
+        last_supp_before_refprop.drop("ref_prop_pos"),
         ["utterance_id","user_id","utterance_start_time","sel_pos"],
         "left"
     )
@@ -203,10 +226,11 @@ def complement_with_local_insertion(
         "utterance_id","user_id","utterance_start_time",
         col("insert_pos").alias("ord_pos"),
         "scenario_id",
+        "insert_kind",
         when(col("insert_kind")=="proposal", lit("提案"))
         .when(col("insert_kind")=="support", lit("サポート"))
         .otherwise(lit("挿入")).alias("route"),
-    ).withColumn("insert_kind", col("insert_kind"))
+    )
 
     merged = original_elems.unionByName(insert_elems, allowMissingColumns=True)
 
@@ -271,6 +295,7 @@ def complement_with_local_insertion(
 # テスト用の最小データ作成
 # ----------------------------
 def create_test_data():
+    """補完ロジックを確認するための最小データセットを作成する。"""
     spark = SparkSession.builder.appName("LocalInsertionDemo").getOrCreate()
 
     chat_data = [
@@ -319,8 +344,10 @@ def create_test_data():
 # 実行例
 # ----------------------------
 if __name__ == "__main__":
+    # サンプルデータを生成して補完処理を実行するデモ
     spark = SparkSession.builder.getOrCreate()
 
+    # テスト用のチャットデータとシナリオマスターを作成
     chat_df, scenario_df = create_test_data()
 
     # 仕様：提案が無い selection は「先頭に S001（＆その直前に support）」を1回だけ追加して満たす
@@ -330,4 +357,5 @@ if __name__ == "__main__":
         HEAD_INSERT_FOR_MISSING_PROPOSAL=True   # ← False にすると各 selection 直前に挿入
     )
 
+    # 補完後の結果を表示
     result.orderBy("user_id","utterance_start_time").show(truncate=False)


### PR DESCRIPTION
## 概要
- routing_select 補完ロジックに詳細な説明とコメントを追加
- サンプルデータ生成関数と実行例のコメントを整備
- 実行時に不足していた DataFrame import とカラム重複の問題を修正

## テスト
- `python chat_script.ipynb > /tmp/test.log 2>&1`
- `tail -n 20 /tmp/test.log | cut -c1-200`


------
https://chatgpt.com/codex/tasks/task_e_68accc09bebc832d8219e530be7387b3