### PR TITLE
chat_script に説明コメントを追加

### DIFF
--- a/chat_script.ipynb
+++ b/chat_script.ipynb
@@ -1,4 +1,4 @@
-from pyspark.sql import SparkSession
+from pyspark.sql import SparkSession, DataFrame
 from pyspark.sql.functions import *
 from pyspark.sql.window import Window
 from pyspark.sql.types import *
@@ -15,8 +15,32 @@ def complement_with_local_insertion(
     scenario_master_df: DataFrame,
     *,
     SUPPORT_DEFAULT: str = "S006",
-    HEAD_INSERT_FOR_MISSING_PROPOSAL: bool = True
+    HEAD_INSERT_FOR_MISSING_PROPOSAL: bool = True,
+    debug: bool = False
 ) -> DataFrame:
+    """
+    routing_select に不足している提案やサポートを補完する。
+
+    各 selection の直前に proposal と support が存在することを保証するため、
+    不足している要素を先頭またはローカル位置に挿入して配列を再構築する。
+
+    Parameters
+    ----------
+    chat_df : DataFrame
+        発話情報と routing_select を持つデータセット
+    scenario_master_df : DataFrame
+        シナリオIDと route 種別の対応表
+    SUPPORT_DEFAULT : str, optional
+        サポートが見つからない場合に使用するデフォルトID（既定値: "S006"）
+    HEAD_INSERT_FOR_MISSING_PROPOSAL : bool, optional
+        True の場合、提案が無い selection への挿入を先頭に集約する
+
+    Returns
+    -------
+    DataFrame
+        補完後の routing_select と挿入数などの付加情報を含むデータセット
+    """
+
     spark = chat_df.sql_ctx.sparkSession
 
     # ---------- 基本の展開 ----------
@@ -25,7 +49,11 @@ def complement_with_local_insertion(
         posexplode("routing_select").alias("position", "scenario_id")
     ).join(broadcast(scenario_master_df), "scenario_id", "left")
 
-    # 各種フィルタビュー
+    if debug:
+        print("=== expl ===")
+        expl.orderBy("utterance_id", "position").show(truncate=False)
+
+    # 各 route ごとの行に分割し、後続処理用に位置情報を保持
     sel = expl.filter(col("route") == "選択") \
               .select("utterance_id","user_id","utterance_start_time","position") \
               .withColumnRenamed("position","sel_pos")
@@ -118,7 +146,7 @@ def complement_with_local_insertion(
     )
 
     per_selection = per_selection.join(
-        last_supp_before_refprop,
+        last_supp_before_refprop.drop("ref_prop_pos"),
         ["utterance_id","user_id","utterance_start_time","sel_pos"],
         "left"
     )
@@ -133,6 +161,10 @@ def complement_with_local_insertion(
         )
 
     per_selection = per_selection.join(per_utt_support_pref, ["utterance_id","user_id","utterance_start_time"], "left")
+
+    if debug:
+        print("=== per_selection ===")
+        per_selection.orderBy("utterance_id", "sel_pos").show(truncate=False)
 
     # ---------- 各 selection の不足判定 ----------
     # A) 直前 proposal が無い → 提案を挿入（位置は sel_pos の直前 or 先頭）
@@ -191,6 +223,10 @@ def complement_with_local_insertion(
         "utterance_id","user_id","utterance_start_time","insert_pos","insert_kind","scenario_id"
     ])
 
+    if debug:
+        print("=== planned_inserts ===")
+        planned_inserts.orderBy("utterance_id", "insert_pos").show(truncate=False)
+
     # ---------- 元要素と挿入要素を結合 → 並び替え → 配列再構成 ----------
     original_elems = expl.select(
         "utterance_id","user_id","utterance_start_time",
@@ -203,10 +239,11 @@ def complement_with_local_insertion(
         "utterance_id","user_id","utterance_start_time",
         col("insert_pos").alias("ord_pos"),
         "scenario_id",
+        "insert_kind",
         when(col("insert_kind")=="proposal", lit("提案"))
         .when(col("insert_kind")=="support", lit("サポート"))
         .otherwise(lit("挿入")).alias("route"),
-    ).withColumn("insert_kind", col("insert_kind"))
+    )
 
     merged = original_elems.unionByName(insert_elems, allowMissingColumns=True)
 
@@ -216,6 +253,10 @@ def complement_with_local_insertion(
                 .otherwise(lit(2))
 
     merged = merged.withColumn("order_key", order_key)
+
+    if debug:
+        print("=== merged ===")
+        merged.orderBy("utterance_id", "ord_pos", "order_key").show(truncate=False)
 
     # 発話単位で position/order_key で並べ、シナリオ配列を再構築
     collected = merged.groupBy("utterance_id","user_id","utterance_start_time") \
@@ -264,6 +305,10 @@ def complement_with_local_insertion(
                      "support_min_pos","proposal_min_pos","selection_min_pos"
                  )
 
+    if debug:
+        print("=== out ===")
+        out.orderBy("user_id", "utterance_start_time").show(truncate=False)
+
     return out
 
 
@@ -271,6 +316,7 @@ def complement_with_local_insertion(
 # テスト用の最小データ作成
 # ----------------------------
 def create_test_data():
+    """補完ロジックを確認するための最小データセットを作成する。"""
     spark = SparkSession.builder.appName("LocalInsertionDemo").getOrCreate()
 
     chat_data = [
@@ -319,15 +365,24 @@ def create_test_data():
 # 実行例
 # ----------------------------
 if __name__ == "__main__":
+    # サンプルデータを生成して補完処理を実行するデモ
     spark = SparkSession.builder.getOrCreate()
 
+    # テスト用のチャットデータとシナリオマスターを作成
     chat_df, scenario_df = create_test_data()
+
+    print("=== chat_df ===")
+    chat_df.orderBy("user_id","utterance_start_time").show(truncate=False)
+    print("=== scenario_df ===")
+    scenario_df.orderBy("scenario_id").show(truncate=False)
 
     # 仕様：提案が無い selection は「先頭に S001（＆その直前に support）」を1回だけ追加して満たす
     result = complement_with_local_insertion(
         chat_df, scenario_df,
         SUPPORT_DEFAULT="S006",
-        HEAD_INSERT_FOR_MISSING_PROPOSAL=True   # ← False にすると各 selection 直前に挿入
+        HEAD_INSERT_FOR_MISSING_PROPOSAL=True,   # ← False にすると各 selection 直前に挿入
+        debug=True
     )
 
+    print("=== final result ===")
     result.orderBy("user_id","utterance_start_time").show(truncate=False)


### PR DESCRIPTION
## 概要
- routing_select 補完ロジックに詳細な説明とコメントを追加
- サンプルデータ生成関数と実行例のコメントを整備
- 実行時に不足していた DataFrame import とカラム重複の問題を修正
- サンプルデータで処理を実行し、各ステップの DataFrame を show で確認できるように調整

## テスト
- `pip install pyspark`
- `python chat_script.ipynb > /tmp/test.log 2>&1`
- `head -n 40 /tmp/test.log | cut -c1-200`
- `tail -n 40 /tmp/test.log | cut -c1-200`


------
https://chatgpt.com/codex/tasks/task_e_68accc09bebc832d8219e530be7387b3